### PR TITLE
Add: Nose JWT decorator 기능 추가

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,30 @@
+import jwt
+
+from django.http import JsonResponse
+from django.conf import settings
+
+from users.models import User
+
+def token_decorator(func):
+    def wrapper(self, request, *args, **kwargs) :
+        try:
+            access_token = request.headers.get("Authorization", None)
+            payload      = jwt.decode(access_token, settings.SECRET_KEY, settings.ALGORITHM)
+            user         = User.objects.get(id = payload["user_id"])
+            request.user = user
+
+            return func(self, request, *args, **kwargs)
+
+        except jwt.exceptions.InvalidSignatureError:
+            return JsonResponse({"message": "INVALID_SIGNATURE_OF_TOKEN"}, status=400)
+
+        except jwt.exceptions.DecodeError:
+            return JsonResponse({"message": "DECODE_ERROR"}, status=400)
+
+        except jwt.exceptions.InvalidTokenError:
+            return JsonResponse({"message": "INVALID_TOKEN"}, status=400)
+
+        except User.DoesNotExist :
+            return JsonResponse({"message": "INNALID_USER"}, status=400)
+
+    return wrapper


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표


__인가__

로그인을 한 유저가 다른 통신을 요청하면서 보낸 JWT 토큰을 확인하여 유저의 요청을 허용하는 데코레이터 함수 작성

<br />
<br />

## :: 구현 사항 설명

1. 요청 - 헤더 부분의 토큰 확인
- { key = Authorization, value = access_token }을 확인하여 access_token을 받아옴.
- 없으면 None 반환

2. payload에 유저 정보 할당.
- 요청에서 받아온 access_token을 서버의 SECRET_KEY와 ALGORITHM 방식을 통해 복호화

3. 유저 정보 확인
- payload의 유저 정보 중 고유 정보가 아닌 모든 데이터가 지니고 있는 정수 데이터인 user_id를 통해 유저의 정보 유무 확인
- 만약 유저 정보 없는 경우 User.DoesNotExist 에러 반환

4. 토큰에 대한 에러 처리 3가지
[pyjwt](https://pyjwt.readthedocs.io/en/latest/api.html#jwt.exceptions.InvalidTokenError)를 참고하여 작성하였습니다.

- jwt.exceptions.InvalidSignatureError >> signature가 유효하지 않을 때 발생하는 에러
- jwt.exceptions.InvalidTokenError       >> 토큰 복호화 실패했을 때 발생하는 에러
- jwt.exceptions.DecodeError               >> 토큰이 유효하지 않아 복호화를 할 수  없을 때 발생하는 에러

<br />
<br />

## :: 성장 포인트

- 발생할 수 있는 에러의 유형을 공부할 수 있었습니다.
- 다양한 에러에 대해 응답 메시지를 어떻게 보내야 할 것인지에 대한 고민을 해보았습니다.

<br />
<br />

## :: 기타 질문 및 특이 사항

-  DecodeError와 InvalidTokenError의 명확한 차이가 궁금합니다.

제가 이해한 내용은 다음과 같습니다:

1) InvalidTokenError 는 토큰의 형식 자체가 잘못되어 복호화를 실패한 경우
2) DecodeError는 서버에서 발행하지 않은 토큰이라 유효하지 않다고 판단을 해서 복호화를 실패하는 경우

문서에는 다음과 같이 구분되어 있습니다.

<img width="407" alt="image" src="https://user-images.githubusercontent.com/93123657/175232519-afef0ca4-073f-4800-99a0-96cc5c3813c3.png">
