### PR TITLE
[Nose] Add: 상품 Detail API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,5 @@ zsdoc/data
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm,visualstudiocode,linux,macos,zsh,vim
 
 my_settings.py
+db_uploads.py
+/csv/*

--- a/nose/urls.py
+++ b/nose/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 
 urlpatterns = [
-    path("users", include("users.urls"))
+    path("users", include("users.urls")),
+    path("products", include("products.urls"))
 ]

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from products.views import ProductDetailView
+
+urlpatterns = [
+    path("/detail/<int:product_id>", ProductDetailView.as_view())
+]

--- a/products/views.py
+++ b/products/views.py
@@ -1,3 +1,22 @@
-from django.shortcuts import render
+from django.views import View
+from django.http  import JsonResponse
 
-# Create your views here.
+from products.models import Product, MainImage
+
+class ProductDetailView(View):
+    def get(self, request, product_id):
+        try:
+            product     = Product.objects.get(id=product_id)
+            main_images = MainImage.objects.filter(product_id=product_id)
+
+            perfume_item = {
+                "product_id"   : product.id,
+                "name"         : product.name,
+                "price"        : product.price,
+                "main_img_url" : [ main_image.main_page_img_url for main_image in main_images ]
+            }
+
+            return JsonResponse({"perfume_item": perfume_item}, status=200)
+
+        except Product.DoesNotExist :
+            return JsonResponse({"message": "NONE_PRODUCT"}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

상품 리스트에서 각 상품을 눌렀을 때 해당 상품의 정보만 보내주는 API 구현

<br />

## :: 구현 사항 설명

1. Path parameter
- path parameter를 통해 상세 정보를 보려는 상품의 정보 (id 값)를 받아옴.

2. 상품의 상세 정보는 데이터 타입을 배열이 아닌 객체로써 전달

<br />

## :: 성장 포인트
- path parameter를 이해하고 언제 사용하는지 공부할 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- (추가하고 싶은 사항) 현재 프로젝트에는 적용하지 않았지만, 상품 상세 페이로 들어갔을 때 옵션을 선택하는 기능을 추가해보고 싶습니다.